### PR TITLE
Make both all_zeroes() functions constant-time

### DIFF
--- a/firmware/lib/bip32/bip32.c
+++ b/firmware/lib/bip32/bip32.c
@@ -13,11 +13,12 @@
 #define KEY_IDENTIFIER_SIZE (HASH160_DIGEST_SIZE)
 
 static bool all_zeroes(uint8_t* buf, uint32_t size) {
+  // Constant-time check for all-0s
+  volatile uint8_t val = 0;
   for (size_t i = 0; i < size; i++) {
-    if (buf[i] != 0)
-      return false;
+    val |= buf[i];
   }
-  return true;
+  return val == 0;
 }
 
 static bool compute_identifier(uint8_t* sec_encoded_pubkey, uint8_t* identifier,

--- a/firmware/lib/crypto/src/ecc.c
+++ b/firmware/lib/crypto/src/ecc.c
@@ -345,11 +345,12 @@ out:
 }
 
 static inline bool all_zeroes(uint8_t* buf, uint32_t size) {
+  // Constant-time check for all-0s
+  volatile uint8_t val = 0;
   for (size_t i = 0; i < size; i++) {
-    if (buf[i] != 0)
-      return false;
+    val |= buf[i];
   }
-  return true;
+  return val == 0;
 }
 
 static void clamp_ed25519_private_key(uint8_t* privkey) {


### PR DESCRIPTION
No need to leak the number of leading zeroes in the secret buffers via a timing side channel.