### PR TITLE
feature/allowPreDownloadedSplitsAPKs

### DIFF
--- a/app/verifiable-build/android/verification/steps/convert-aab-to-apks
+++ b/app/verifiable-build/android/verification/steps/convert-aab-to-apks
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-# Converts locally built AAB to a set of APKs based on the configuration of the connected Android device.
+# Converts locally built AAB to a set of APKs based on the provided device specification or connected Android device.
 
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <path-to-aab> <path-to-output-directory>" >&2
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    echo "Usage: $0 <path-to-aab> <path-to-output-directory> [path-to-device-spec.json]" >&2
     exit 1
 fi
 
 if [ ! -f "$1" ] || [[ $1 != *.aab ]]; then
     echo "$1 is not an AAB"
-    echo "Usage: $0 <path-to-aab> <path-to-output-directory>" >&2
+    echo "Usage: $0 <path-to-aab> <path-to-output-directory> [path-to-device-spec.json]" >&2
     exit 2
 fi
 
@@ -36,13 +36,19 @@ if ! which "unzip" > /dev/null 2>&1; then
     exit 100
 fi
 
-
 mkdir -p "$2"
 mkdir -p "$2/tmp"
 
-java -jar "$BUNDLETOOL" build-apks --connected-device --bundle="$1" --output="$2/tmp/apks.apks" || exit $?
+if [ -n "$3" ]; then
+    if [ ! -f "$3" ]; then
+        echo "Specified device-spec.json file does not exist." >&2
+        exit 4
+    fi
+    java -jar "$BUNDLETOOL" build-apks --device-spec="$3" --bundle="$1" --output="$2/tmp/apks.apks" || exit $?
+else
+    java -jar "$BUNDLETOOL" build-apks --connected-device --bundle="$1" --output="$2/tmp/apks.apks" || exit $?
+fi
+
 unzip "$2/tmp/apks.apks" -d "$2/tmp"
-
 find "$2/tmp" -type f -name "*.apk" -exec mv {} "$2" \;
-
 rm -rf "$2/tmp"

--- a/app/verifiable-build/android/verification/verify-android-apk
+++ b/app/verifiable-build/android/verification/verify-android-apk
@@ -1,17 +1,41 @@
 #!/bin/bash
-
 # Verifies that an APK installed on a real device was build from the given source code.
 # The script assumes that there is an established ADB session with a phone that contains the app to verify.
 # The build directory is used for temporary storage and is not deleted afterwards so that the user can inspect the outputs of each verification step or do certain steps manually.
+# Option to run script and compare from pre-downloaded apks and specify a device-spec.json file.
+# ./verify-android-apk -d /path/to/apk/directory -s /path/to/device-spec.json /path/to/bitkey/repo /path/to/build/directory
+
+apkSourceDir=""
+deviceSpecFile=""
+
+# Parse the new options first
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -d|--apk-dir)
+      apkSourceDir="$2"
+      shift 2
+      ;;
+    -s|--device-spec)
+      deviceSpecFile="$2"
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <path-to-bitkey-repository-directory> <path-to-build-directory>" >&2
+    echo "Usage: $0 [-d|--apk-dir <directory>] [-s|--device-spec <file>] <path-to-bitkey-repository-directory> <path-to-build-directory>" >&2
+    echo "Options:" >&2
+    echo "  -d|--apk-dir      Directory containing pre-downloaded APKs" >&2
+    echo "  -s|--device-spec  Path to device-spec.json file" >&2
     exit 1
 fi
 
 if [ ! -f "$1/app/verifiable-build/android/Dockerfile" ]; then
     echo "Cannot find the Dockerfile used for building the AAB. Ensure the path points to the root directory of the Bitkey repository." >&2
-    echo "Usage: $0 <path-to-bitkey-repository-directory> <path-to-build-directory>" >&2
+    echo "Usage: $0 [-d|--apk-dir <directory>] [-s|--device-spec <file>] <path-to-bitkey-repository-directory> <path-to-build-directory>" >&2
     exit 2
 fi
 
@@ -26,8 +50,15 @@ mkdir -p "$2"
 
 steps_path="$1/app/verifiable-build/android/verification/steps"
 
-printf "Downloading APK from phone:\n\n"
-"$steps_path/download-apk-from-phone" "$package_name" "$2/from-device/downloaded" || exit $?
+if [ -n "$apkSourceDir" ]; then
+  printf "Copying APKs from specified directory:\n\n"
+  mkdir -p "$2/from-device/downloaded"
+  cp "$apkSourceDir"/* "$2/from-device/downloaded/" || exit $?
+  echo "APKs copied successfully."
+else
+  printf "Downloading APK from phone:\n\n"
+  "$steps_path/download-apk-from-phone" "$package_name" "$2/from-device/downloaded" || exit $?
+fi
 
 printf "Normalizing names of downloaded APKs:\n\n"
 "$steps_path/normalize-apk-names-new" "$2/from-device/downloaded" "$2/from-device/normalized-names" "device" || exit $?
@@ -46,7 +77,11 @@ printf "Building AAB from source code:\n\n"
 aab_path=$(find "$2/locally-built/aab" -type f -name "*.aab")
 
 printf "Converting AAB to APKs:\n\n"
-"$steps_path/convert-aab-to-apks" "$aab_path" "$2/locally-built/apks" || exit $?
+if [ -n "$deviceSpecFile" ]; then
+  "$steps_path/convert-aab-to-apks" "$aab_path" "$2/locally-built/apks" "$deviceSpecFile" || exit $?
+else
+  "$steps_path/convert-aab-to-apks" "$aab_path" "$2/locally-built/apks" || exit $?
+fi
 
 printf "Normalizing names of locally built APKs:\n\n"
 "$steps_path/normalize-apk-names-new" "$2/locally-built/apks" "$2/locally-built/normalized-names" "bundletool" || exit $?


### PR DESCRIPTION
Hello team bitkey! 

Danny here from WalletScrutiny. I recently did a build for version **2024.63.0 (4)**. And it came out as **reproducible**

WalletScrutiny has a remote debian based build server that cannot connect to my phone. :)
Doing the build on a local machine with a connected phone crashes for me. 

(You can skip to the end part of the asciicast)

https://asciinema.org/a/hZFLhGnDU8i4ijh4A0oxYg66i

I just thought I'd share a little modification I made to your verification script. 

**Step 1**: Download the Split APKs from phone on a local machine by running `steps/download-apk-from-phone`
**Step 2**: Generate the *device-spec.json* file with `bundletool get-device-spec --output=device-spec.json`
**Step 3**: Upload the split apks and device-spec.json on local machine to a folder on build server
**Step 4**: Proceed with the instructions [here.](https://github.com/proto-at-block/bitkey/tree/main/app/verifiable-build/android). 
- After cloning, change the following scripts: `verify-android-apk` and `convert-aab-to-apks` which I included in this PR.

**Step 5** Proceed with other prep steps. Then run `verify-android-apk` with

```
$ ./verify-android-apk -d /path/to/apk/directory -s /path/to/device-spec.json /path/to/bitkey/repo/on/build/machine /path/to/build/directory/on/build/machine
```

