### PR TITLE
Add ability to select UTXOs when sending sats

### DIFF
--- a/app/domain/analytics/public/src/commonMain/kotlin/build/wallet/analytics/events/screen/id/SendEventTrackerScreenId.kt
+++ b/app/domain/analytics/public/src/commonMain/kotlin/build/wallet/analytics/events/screen/id/SendEventTrackerScreenId.kt
@@ -42,4 +42,7 @@ enum class SendEventTrackerScreenId : EventTrackerScreenId {
 
   /** Error screen shown when server signing fails and hardware is required */
   SEND_SERVER_SIGNING_ERROR,
+
+  /** Optional advanced screen for selecting confirmed UTXOs during send */
+  SEND_UTXO_SELECTION,
 }

--- a/app/domain/wallet/fake/src/commonMain/kotlin/build/wallet/bitcoin/fees/BitcoinTransactionFeeEstimatorMock.kt
+++ b/app/domain/wallet/fake/src/commonMain/kotlin/build/wallet/bitcoin/fees/BitcoinTransactionFeeEstimatorMock.kt
@@ -24,6 +24,8 @@ class BitcoinTransactionFeeEstimatorMock(
       )
     ),
 ) : BitcoinTransactionFeeEstimator {
+  var lastCoinControl: CoinControl? = null
+
   override suspend fun getFeesForTransaction(
     priorities: List<EstimatedTransactionPriority>,
     account: FullAccount,
@@ -31,6 +33,7 @@ class BitcoinTransactionFeeEstimatorMock(
     amount: BitcoinTransactionSendAmount,
     coinControl: CoinControl?,
   ): Result<Map<EstimatedTransactionPriority, Fee>, FeeEstimationError> {
+    lastCoinControl = coinControl
     return feesResult
   }
 }

--- a/app/domain/wallet/fake/src/commonMain/kotlin/build/wallet/bitcoin/fees/BitcoinTransactionFeeEstimatorMock.kt
+++ b/app/domain/wallet/fake/src/commonMain/kotlin/build/wallet/bitcoin/fees/BitcoinTransactionFeeEstimatorMock.kt
@@ -7,6 +7,7 @@ import build.wallet.bitcoin.transactions.EstimatedTransactionPriority
 import build.wallet.bitcoin.transactions.EstimatedTransactionPriority.FASTEST
 import build.wallet.bitcoin.transactions.EstimatedTransactionPriority.SIXTY_MINUTES
 import build.wallet.bitcoin.transactions.EstimatedTransactionPriority.THIRTY_MINUTES
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.bitkey.account.FullAccount
 import build.wallet.money.BitcoinMoney
 import com.github.michaelbull.result.Ok
@@ -28,6 +29,7 @@ class BitcoinTransactionFeeEstimatorMock(
     account: FullAccount,
     recipientAddress: BitcoinAddress,
     amount: BitcoinTransactionSendAmount,
+    coinControl: CoinControl?,
   ): Result<Map<EstimatedTransactionPriority, Fee>, FeeEstimationError> {
     return feesResult
   }

--- a/app/domain/wallet/fake/src/commonMain/kotlin/build/wallet/bitcoin/transactions/BitcoinWalletServiceFake.kt
+++ b/app/domain/wallet/fake/src/commonMain/kotlin/build/wallet/bitcoin/transactions/BitcoinWalletServiceFake.kt
@@ -1,6 +1,7 @@
 package build.wallet.bitcoin.transactions
 
 import build.wallet.bitcoin.address.BitcoinAddress
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.bitcoin.wallet.SpendingWallet
 import build.wallet.time.someInstant
 import com.github.michaelbull.result.Err
@@ -58,6 +59,7 @@ class BitcoinWalletServiceFake : BitcoinWalletService {
   override suspend fun createPsbtsForSendAmount(
     sendAmount: BitcoinTransactionSendAmount,
     recipientAddress: BitcoinAddress,
+    coinControl: CoinControl?,
   ): Result<PsbtsForSendAmount, Error> {
     return createPsbtsForSendAmountResult ?: Ok(
       PsbtsForSendAmount(

--- a/app/domain/wallet/fake/src/commonMain/kotlin/build/wallet/bitcoin/transactions/BitcoinWalletServiceFake.kt
+++ b/app/domain/wallet/fake/src/commonMain/kotlin/build/wallet/bitcoin/transactions/BitcoinWalletServiceFake.kt
@@ -55,12 +55,14 @@ class BitcoinWalletServiceFake : BitcoinWalletService {
   }
 
   var createPsbtsForSendAmountResult: Result<PsbtsForSendAmount, Error>? = null
+  var lastCreatePsbtsCoinControl: CoinControl? = null
 
   override suspend fun createPsbtsForSendAmount(
     sendAmount: BitcoinTransactionSendAmount,
     recipientAddress: BitcoinAddress,
     coinControl: CoinControl?,
   ): Result<PsbtsForSendAmount, Error> {
+    lastCreatePsbtsCoinControl = coinControl
     return createPsbtsForSendAmountResult ?: Ok(
       PsbtsForSendAmount(
         fastest = PsbtMock,
@@ -78,5 +80,6 @@ class BitcoinWalletServiceFake : BitcoinWalletService {
     spendingWallet.value = null
     syncResult = Ok(Unit)
     createPsbtsForSendAmountResult = null
+    lastCreatePsbtsCoinControl = null
   }
 }

--- a/app/domain/wallet/impl/src/commonMain/kotlin/build/wallet/bitcoin/fees/BitcoinTransactionFeeEstimatorImpl.kt
+++ b/app/domain/wallet/impl/src/commonMain/kotlin/build/wallet/bitcoin/fees/BitcoinTransactionFeeEstimatorImpl.kt
@@ -11,6 +11,8 @@ import build.wallet.bitcoin.fees.BitcoinTransactionFeeEstimator.FeeEstimationErr
 import build.wallet.bitcoin.transactions.BitcoinTransactionSendAmount
 import build.wallet.bitcoin.transactions.BitcoinWalletService
 import build.wallet.bitcoin.transactions.EstimatedTransactionPriority
+import build.wallet.bitcoin.utxo.CoinControl
+import build.wallet.bitcoin.utxo.toCoinSelectionStrategy
 import build.wallet.bitkey.account.FullAccount
 import build.wallet.di.AppScope
 import build.wallet.di.BitkeyInject
@@ -39,6 +41,7 @@ class BitcoinTransactionFeeEstimatorImpl(
     account: FullAccount,
     recipientAddress: BitcoinAddress,
     amount: BitcoinTransactionSendAmount,
+    coinControl: CoinControl?,
   ): Result<Map<EstimatedTransactionPriority, Fee>, FeeEstimationError> {
     return coroutineBinding {
       // Fetch the fee rates for transaction priorities and use them to create transactions for each
@@ -60,7 +63,8 @@ class BitcoinTransactionFeeEstimatorImpl(
           .createPsbt(
             recipientAddress = recipientAddress,
             amount = amount,
-            feePolicy = FeePolicy.MinRelayRate
+            feePolicy = FeePolicy.MinRelayRate,
+            coinSelectionStrategy = coinControl.toCoinSelectionStrategy()
           )
           .logFailure { "Error creating psbt with tracking keyset" }
           .onFailure {

--- a/app/domain/wallet/impl/src/commonMain/kotlin/build/wallet/bitcoin/transactions/BitcoinWalletServiceImpl.kt
+++ b/app/domain/wallet/impl/src/commonMain/kotlin/build/wallet/bitcoin/transactions/BitcoinWalletServiceImpl.kt
@@ -16,7 +16,9 @@ import build.wallet.bitcoin.fees.FeePolicy
 import build.wallet.bitcoin.fees.FeeRatesByPriority
 import build.wallet.bitcoin.transactions.BitcoinTransaction.ConfirmationStatus.Confirmed
 import build.wallet.bitcoin.transactions.BitcoinWalletServiceImpl.Balances.LoadedBalance
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.bitcoin.utxo.Utxos
+import build.wallet.bitcoin.utxo.toCoinSelectionStrategy
 import build.wallet.bitcoin.wallet.CoinSelectionStrategy
 import build.wallet.bitcoin.wallet.SpendingWallet
 import build.wallet.bitcoin.wallet.SpendingWalletV2Impl
@@ -252,6 +254,7 @@ class BitcoinWalletServiceImpl(
   override suspend fun createPsbtsForSendAmount(
     sendAmount: BitcoinTransactionSendAmount,
     recipientAddress: BitcoinAddress,
+    coinControl: CoinControl?,
   ): Result<PsbtsForSendAmount, Error> =
     coroutineBinding {
       val wallet = spendingWallet.value
@@ -266,62 +269,101 @@ class BitcoinWalletServiceImpl(
       val feeRates = feeRateEstimator.getEstimatedFeeRates(wallet.networkType)
         .bind()
 
+      val coinSelectionStrategy = coinControl.toCoinSelectionStrategy()
       when (sendAmount) {
-        is BitcoinTransactionSendAmount.ExactAmount -> createExactAmountPsbts(
-          wallet = wallet,
-          recipientAddress = recipientAddress,
-          sendAmount = sendAmount,
-          feeRates = feeRates
-        ).bind()
+        is BitcoinTransactionSendAmount.ExactAmount ->
+          if (coinSelectionStrategy is CoinSelectionStrategy.Strict) {
+            createPsbtsWithFixedStrategy(
+              wallet = wallet,
+              recipientAddress = recipientAddress,
+              sendAmount = sendAmount,
+              feeRates = feeRates,
+              coinSelectionStrategy = coinSelectionStrategy
+            ).bind()
+          } else {
+            createExactAmountPsbts(
+              wallet = wallet,
+              recipientAddress = recipientAddress,
+              sendAmount = sendAmount,
+              feeRates = feeRates
+            ).bind()
+          }
         is BitcoinTransactionSendAmount.SendAll -> createSendAllPsbts(
           wallet = wallet,
           recipientAddress = recipientAddress,
-          feeRates = feeRates
+          feeRates = feeRates,
+          coinSelectionStrategy = coinSelectionStrategy
         ).bind()
       }
+    }
+
+  private suspend fun createPsbtsWithFixedStrategy(
+    wallet: SpendingWallet,
+    recipientAddress: BitcoinAddress,
+    sendAmount: BitcoinTransactionSendAmount,
+    feeRates: FeeRatesByPriority,
+    coinSelectionStrategy: CoinSelectionStrategy,
+  ): Result<PsbtsForSendAmount, Error> =
+    coroutineBinding {
+      val sixtyMinutesPsbt = wallet.createSignedPsbt(
+        constructionType = SpendingWallet.PsbtConstructionMethod.Regular(
+          recipientAddress = recipientAddress,
+          amount = sendAmount,
+          feePolicy = FeePolicy.Rate(feeRate = feeRates.hourFeeRate),
+          coinSelectionStrategy = coinSelectionStrategy
+        )
+      ).mapError { Error("Error creating PSBT for 60 minutes") }
+        .bind()
+
+      val thirtyMinutesPsbt = wallet.createSignedPsbt(
+        constructionType = SpendingWallet.PsbtConstructionMethod.Regular(
+          recipientAddress = recipientAddress,
+          amount = sendAmount,
+          feePolicy = FeePolicy.Rate(feeRate = feeRates.halfHourFeeRate),
+          coinSelectionStrategy = coinSelectionStrategy
+        )
+      ).getOrElse {
+        return@coroutineBinding PsbtsForSendAmount(
+          fastest = null,
+          thirtyMinutes = null,
+          sixtyMinutes = sixtyMinutesPsbt
+        )
+      }
+
+      val fastestPsbt = wallet.createSignedPsbt(
+        constructionType = SpendingWallet.PsbtConstructionMethod.Regular(
+          recipientAddress = recipientAddress,
+          amount = sendAmount,
+          feePolicy = FeePolicy.Rate(feeRate = feeRates.fastestFeeRate),
+          coinSelectionStrategy = coinSelectionStrategy
+        )
+      ).getOrElse {
+        return@coroutineBinding PsbtsForSendAmount(
+          fastest = null,
+          thirtyMinutes = thirtyMinutesPsbt,
+          sixtyMinutes = sixtyMinutesPsbt
+        )
+      }
+
+      PsbtsForSendAmount(
+        fastest = fastestPsbt,
+        thirtyMinutes = thirtyMinutesPsbt,
+        sixtyMinutes = sixtyMinutesPsbt
+      )
     }
 
   private suspend fun createSendAllPsbts(
     wallet: SpendingWallet,
     recipientAddress: BitcoinAddress,
     feeRates: FeeRatesByPriority,
-  ) = coroutineBinding {
-    val sixtyMinutesPsbt = wallet.createSignedPsbt(
-      constructionType = SpendingWallet.PsbtConstructionMethod.Regular(
-        recipientAddress = recipientAddress,
-        amount = BitcoinTransactionSendAmount.SendAll,
-        feePolicy = FeePolicy.Rate(feeRate = feeRates.hourFeeRate),
-        coinSelectionStrategy = CoinSelectionStrategy.Default
-      )
-    ).mapError { Error("Error creating PSBT for 60 minutes") }
-      .bind()
-
-    val thirtyMinutesPsbt = wallet.createSignedPsbt(
-      constructionType = SpendingWallet.PsbtConstructionMethod.Regular(
-        recipientAddress = recipientAddress,
-        amount = BitcoinTransactionSendAmount.SendAll,
-        feePolicy = FeePolicy.Rate(feeRate = feeRates.halfHourFeeRate),
-        coinSelectionStrategy = CoinSelectionStrategy.Default
-      )
-    ).mapError { Error("Error creating PSBT for 30 minutes") }
-      .bind()
-
-    val fastestPsbt = wallet.createSignedPsbt(
-      constructionType = SpendingWallet.PsbtConstructionMethod.Regular(
-        recipientAddress = recipientAddress,
-        amount = BitcoinTransactionSendAmount.SendAll,
-        feePolicy = FeePolicy.Rate(feeRate = feeRates.fastestFeeRate),
-        coinSelectionStrategy = CoinSelectionStrategy.Default
-      )
-    ).mapError { Error("Error creating PSBT for fastest") }
-      .bind()
-
-    PsbtsForSendAmount(
-      fastest = fastestPsbt,
-      thirtyMinutes = thirtyMinutesPsbt,
-      sixtyMinutes = sixtyMinutesPsbt
-    )
-  }
+    coinSelectionStrategy: CoinSelectionStrategy,
+  ) = createPsbtsWithFixedStrategy(
+    wallet = wallet,
+    recipientAddress = recipientAddress,
+    sendAmount = BitcoinTransactionSendAmount.SendAll,
+    feeRates = feeRates,
+    coinSelectionStrategy = coinSelectionStrategy
+  )
 
   private suspend fun createExactAmountPsbts(
     wallet: SpendingWallet,

--- a/app/domain/wallet/public/src/commonMain/kotlin/build/wallet/bitcoin/fees/BitcoinTransactionFeeEstimator.kt
+++ b/app/domain/wallet/public/src/commonMain/kotlin/build/wallet/bitcoin/fees/BitcoinTransactionFeeEstimator.kt
@@ -3,6 +3,7 @@ package build.wallet.bitcoin.fees
 import build.wallet.bitcoin.address.BitcoinAddress
 import build.wallet.bitcoin.transactions.BitcoinTransactionSendAmount
 import build.wallet.bitcoin.transactions.EstimatedTransactionPriority
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.bitkey.account.FullAccount
 import build.wallet.money.Money
 import com.github.michaelbull.result.Result
@@ -26,6 +27,7 @@ interface BitcoinTransactionFeeEstimator {
     account: FullAccount,
     recipientAddress: BitcoinAddress,
     amount: BitcoinTransactionSendAmount,
+    coinControl: CoinControl? = null,
   ): Result<Map<EstimatedTransactionPriority, Fee>, FeeEstimationError>
 
   /**

--- a/app/domain/wallet/public/src/commonMain/kotlin/build/wallet/bitcoin/transactions/BitcoinWalletService.kt
+++ b/app/domain/wallet/public/src/commonMain/kotlin/build/wallet/bitcoin/transactions/BitcoinWalletService.kt
@@ -1,6 +1,7 @@
 package build.wallet.bitcoin.transactions
 
 import build.wallet.bitcoin.address.BitcoinAddress
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.bitcoin.wallet.SpendingWallet
 import com.github.michaelbull.result.Result
 import kotlinx.coroutines.flow.StateFlow
@@ -43,10 +44,12 @@ interface BitcoinWalletService {
    *
    * @param sendAmount - the amount to send
    * @param recipientAddress - the address to send to
+   * @param coinControl - optional user-selected confirmed UTXOs; null uses default coin selection
    */
   suspend fun createPsbtsForSendAmount(
     sendAmount: BitcoinTransactionSendAmount,
     recipientAddress: BitcoinAddress,
+    coinControl: CoinControl? = null,
   ): Result<PsbtsForSendAmount, Error>
 }
 

--- a/app/domain/wallet/public/src/commonMain/kotlin/build/wallet/bitcoin/utxo/CoinControl.kt
+++ b/app/domain/wallet/public/src/commonMain/kotlin/build/wallet/bitcoin/utxo/CoinControl.kt
@@ -1,0 +1,74 @@
+package build.wallet.bitcoin.utxo
+
+import build.wallet.bdk.bindings.BdkOutPoint
+import build.wallet.bdk.bindings.BdkTxIn
+import build.wallet.bdk.bindings.BdkUtxo
+import build.wallet.bitcoin.bdk.bitcoinAmount
+import build.wallet.bitcoin.wallet.CoinSelectionStrategy
+import build.wallet.money.BitcoinMoney
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+
+/**
+ * User-chosen confirmed UTXOs for a Regular send.
+ *
+ * Invariants:
+ * - [outpoints] is non-empty
+ * - every outpoint was present in the confirmed inventory at creation
+ * - [spendableTotal] is derived from those UTXOs' values
+ */
+class CoinControl private constructor(
+  private val utxos: Set<BdkUtxo>,
+) {
+  val outpoints: Set<BdkOutPoint>
+    get() = utxos.map { it.outPoint }.toSet()
+
+  val spendableTotal: BitcoinMoney
+    get() = utxos.fold(BitcoinMoney.zero()) { acc, utxo -> acc + utxo.bitcoinAmount }
+
+  val count: Int get() = utxos.size
+
+  fun toStrictStrategy(): CoinSelectionStrategy.Strict =
+    CoinSelectionStrategy.Strict(
+      inputs = utxos.map { it.toSelectionInput() }.toSet()
+    )
+
+  companion object {
+    fun create(
+      inventory: Set<BdkUtxo>,
+      selected: Set<BdkOutPoint>,
+    ): Result<CoinControl, CoinControlError> {
+      if (selected.isEmpty()) {
+        return Err(CoinControlError.EmptySelection)
+      }
+
+      val inventoryByOutpoint = inventory.associateBy { it.outPoint }
+      val missing = selected.filterNot { it in inventoryByOutpoint }.toSet()
+      if (missing.isNotEmpty()) {
+        return Err(CoinControlError.UnknownOrUnconfirmedOutpoints(missing))
+      }
+
+      val chosen = selected.map { inventoryByOutpoint.getValue(it) }.toSet()
+      return Ok(CoinControl(chosen))
+    }
+  }
+}
+
+sealed class CoinControlError {
+  data object EmptySelection : CoinControlError()
+
+  data class UnknownOrUnconfirmedOutpoints(
+    val bad: Set<BdkOutPoint>,
+  ) : CoinControlError()
+}
+
+fun CoinControl?.toCoinSelectionStrategy(): CoinSelectionStrategy =
+  this?.toStrictStrategy() ?: CoinSelectionStrategy.Default
+
+private fun BdkUtxo.toSelectionInput(): BdkTxIn =
+  BdkTxIn(
+    outpoint = outPoint,
+    sequence = 0u,
+    witness = emptyList()
+  )

--- a/app/domain/wallet/public/src/commonTest/kotlin/build/wallet/bitcoin/utxo/CoinControlTests.kt
+++ b/app/domain/wallet/public/src/commonTest/kotlin/build/wallet/bitcoin/utxo/CoinControlTests.kt
@@ -1,0 +1,77 @@
+package build.wallet.bitcoin.utxo
+
+import build.wallet.bdk.bindings.BdkOutPoint
+import build.wallet.bdk.bindings.BdkUtxoMock
+import build.wallet.bdk.bindings.BdkUtxoMock2
+import build.wallet.bitcoin.wallet.CoinSelectionStrategy
+import build.wallet.money.BitcoinMoney
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class CoinControlTests : FunSpec({
+  val utxoA = BdkUtxoMock
+  val utxoB = BdkUtxoMock2.copy(
+    outPoint = BdkOutPoint(txid = "def", vout = 1u)
+  )
+  val inventory = setOf(utxoA, utxoB)
+
+  test("create accepts a non-empty confirmed subset") {
+    val coinControl = CoinControl.create(
+      inventory = inventory,
+      selected = setOf(utxoA.outPoint)
+    ).get().shouldNotBeNull()
+
+    coinControl.count shouldBe 1
+    coinControl.outpoints shouldBe setOf(utxoA.outPoint)
+    coinControl.spendableTotal shouldBe BitcoinMoney.sats(1)
+  }
+
+  test("create sums spendableTotal across selected UTXOs") {
+    val coinControl = CoinControl.create(
+      inventory = inventory,
+      selected = setOf(utxoA.outPoint, utxoB.outPoint)
+    ).get().shouldNotBeNull()
+
+    coinControl.spendableTotal shouldBe BitcoinMoney.sats(3)
+  }
+
+  test("create rejects empty selection") {
+    CoinControl.create(inventory = inventory, selected = emptySet()).getError() shouldBe
+      CoinControlError.EmptySelection
+  }
+
+  test("create rejects unknown or unconfirmed outpoints") {
+    val unknown = BdkOutPoint(txid = "missing", vout = 0u)
+    CoinControl.create(
+      inventory = setOf(utxoA),
+      selected = setOf(utxoA.outPoint, unknown)
+    ).getError() shouldBe CoinControlError.UnknownOrUnconfirmedOutpoints(setOf(unknown))
+  }
+
+  test("toStrictStrategy maps selected outpoints") {
+    val coinControl = CoinControl.create(
+      inventory = inventory,
+      selected = setOf(utxoB.outPoint)
+    ).get().shouldNotBeNull()
+
+    val strategy = coinControl.toStrictStrategy()
+    strategy.inputs.map { it.outpoint }.toSet() shouldBe setOf(utxoB.outPoint)
+  }
+
+  test("null CoinControl maps to Default strategy") {
+    (null as CoinControl?).toCoinSelectionStrategy() shouldBe CoinSelectionStrategy.Default
+  }
+
+  test("present CoinControl maps to Strict strategy") {
+    val coinControl = CoinControl.create(
+      inventory = inventory,
+      selected = setOf(utxoA.outPoint)
+    ).get().shouldNotBeNull()
+
+    coinControl.toCoinSelectionStrategy().shouldBeInstanceOf<CoinSelectionStrategy.Strict>()
+  }
+})

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/SendAmountEntryUiStateMachine.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/SendAmountEntryUiStateMachine.kt
@@ -3,6 +3,7 @@ package build.wallet.statemachine.send
 import build.wallet.bitcoin.address.BitcoinAddress
 import build.wallet.bitcoin.transactions.BitcoinTransactionSendAmount
 import build.wallet.bitcoin.transactions.PsbtsForSendAmount
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.money.Money
 import build.wallet.money.exchange.ExchangeRate
 import build.wallet.statemachine.core.ScreenModel
@@ -23,6 +24,8 @@ interface SendAmountEntryUiStateMachine : StateMachine<SendAmountEntryUiProps, S
  * @property initialAmount - initial bitcoin transfer amount.
  * @property exchangeRates - exchange rates to use for currency conversion. We do this so we can use
  * a consistent set of exchange rates for the entire send flow.
+ * @property coinControl - optional user-selected confirmed UTXOs; null means automatic selection.
+ * @property onCoinControlChanged - updates parent selection (null restores Automatic).
  * @property onContinueClick - handler for proceeding with the transaction without pre-built PSBTs.
  * @property onContinueWithPreBuiltPsbts - handler for proceeding with pre-built PSBTs when the
  *   feature flag is enabled.
@@ -33,6 +36,8 @@ data class SendAmountEntryUiProps(
   val initialAmount: Money,
   val exchangeRates: ImmutableList<ExchangeRate>?,
   val allowSendAll: Boolean = true,
+  val coinControl: CoinControl? = null,
+  val onCoinControlChanged: (CoinControl?) -> Unit = {},
   val onContinueClick: (BitcoinTransactionSendAmount) -> Unit,
   val onContinueWithPreBuiltPsbts: (
     BitcoinTransactionSendAmount,

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/SendAmountEntryUiStateMachineImpl.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/SendAmountEntryUiStateMachineImpl.kt
@@ -8,10 +8,14 @@ import build.wallet.di.ActivityScope
 import build.wallet.di.BitkeyInject
 import build.wallet.feature.flags.PreBuiltPsbtFlowFeatureFlag
 import build.wallet.feature.isEnabled
+import build.wallet.money.BitcoinMoney
+import build.wallet.money.formatter.MoneyDisplayFormatter
 import build.wallet.statemachine.core.ErrorData
 import build.wallet.statemachine.core.LoadingBodyModel
 import build.wallet.statemachine.core.ScreenModel
 import build.wallet.statemachine.moneyhome.MoneyHomeAppSegment
+import build.wallet.statemachine.send.utxo.UtxoSelectionUiProps
+import build.wallet.statemachine.send.utxo.UtxoSelectionUiStateMachine
 import build.wallet.statemachine.transactions.fee.FeeEstimationErrorContext
 import build.wallet.statemachine.transactions.fee.FeeEstimationErrorUiError
 import build.wallet.statemachine.transactions.fee.FeeEstimationErrorUiProps
@@ -22,9 +26,11 @@ import com.github.michaelbull.result.onSuccess
 @BitkeyInject(ActivityScope::class)
 class SendAmountEntryUiStateMachineImpl(
   private val transferAmountEntryUiStateMachine: TransferAmountEntryUiStateMachine,
+  private val utxoSelectionUiStateMachine: UtxoSelectionUiStateMachine,
   private val preBuiltPsbtFlowFeatureFlag: PreBuiltPsbtFlowFeatureFlag,
   private val bitcoinWalletService: BitcoinWalletService,
   private val feeEstimationErrorUiStateMachine: FeeEstimationErrorUiStateMachine,
+  private val moneyDisplayFormatter: MoneyDisplayFormatter,
 ) : SendAmountEntryUiStateMachine {
   @Composable
   override fun model(props: SendAmountEntryUiProps): ScreenModel {
@@ -36,20 +42,32 @@ class SendAmountEntryUiStateMachineImpl(
 
     return when (val state = uiState) {
       is UiState.ViewingCalculator -> {
+        val coinControlLabel = props.coinControl?.let { control ->
+          val countLabel = if (control.count == 1) "1 coin" else "${control.count} coins"
+          "$countLabel · ${moneyDisplayFormatter.format(control.spendableTotal)}"
+        }
+
         transferAmountEntryUiStateMachine.model(
           props = TransferAmountEntryUiProps(
             onBack = props.onBack,
             initialAmount = props.initialAmount,
             exchangeRates = props.exchangeRates,
-            flow = TransferAmountEntryUiProps.Flow.Send(allowSendAll = props.allowSendAll),
+            flow = TransferAmountEntryUiProps.Flow.Send(
+              allowSendAll = props.allowSendAll,
+              coinControlLabel = coinControlLabel,
+              onChooseCoinsClick = { enteredAmount ->
+                uiState = UiState.ChoosingUtxos(targetAmount = enteredAmount)
+              },
+              onClearCoinControl = {
+                props.onCoinControlChanged(null)
+              }
+            ),
             onContinueClick = { continueParams ->
               if (isPreBuiltPsbtFlowEnabled) {
-                // Transition to building state when feature flag is enabled
                 uiState = UiState.BuildingTransactions(
                   sendAmount = continueParams.sendAmount
                 )
               } else {
-                // Continue with standard flow
                 props.onContinueClick(continueParams.sendAmount)
               }
             }
@@ -57,16 +75,33 @@ class SendAmountEntryUiStateMachineImpl(
         )
       }
 
+      is UiState.ChoosingUtxos -> utxoSelectionUiStateMachine.model(
+        props = UtxoSelectionUiProps(
+          targetAmount = state.targetAmount,
+          initialSelection = props.coinControl,
+          onConfirm = { coinControl ->
+            props.onCoinControlChanged(coinControl)
+            uiState = UiState.ViewingCalculator
+          },
+          onClear = {
+            props.onCoinControlChanged(null)
+            uiState = UiState.ViewingCalculator
+          },
+          onBack = {
+            uiState = UiState.ViewingCalculator
+          }
+        )
+      )
+
       is UiState.BuildingTransactions -> {
         LaunchedEffect("build-transactions") {
           bitcoinWalletService.createPsbtsForSendAmount(
             sendAmount = state.sendAmount,
-            recipientAddress = props.recipientAddress
+            recipientAddress = props.recipientAddress,
+            coinControl = props.coinControl
           ).onSuccess { psbts ->
-            // Pass pre-built PSBTs to the next state
             props.onContinueWithPreBuiltPsbts(state.sendAmount, psbts)
           }.onFailure { error ->
-            // Transition to error state
             uiState = UiState.ViewingError(
               sendAmount = state.sendAmount,
               error = error
@@ -87,7 +122,6 @@ class SendAmountEntryUiStateMachineImpl(
         props = FeeEstimationErrorUiProps(
           error = FeeEstimationErrorUiError.InsufficientFunds,
           onBack = {
-            // Return to calculator on back from error
             uiState = UiState.ViewingCalculator
           },
           errorData = ErrorData(
@@ -103,21 +137,16 @@ class SendAmountEntryUiStateMachineImpl(
 }
 
 private sealed interface UiState {
-  /**
-   * Customer is viewing the amount calculator.
-   */
   data object ViewingCalculator : UiState
 
-  /**
-   * Building transactions with pre-built PSBTs.
-   */
+  data class ChoosingUtxos(
+    val targetAmount: BitcoinMoney,
+  ) : UiState
+
   data class BuildingTransactions(
     val sendAmount: BitcoinTransactionSendAmount,
   ) : UiState
 
-  /**
-   * Viewing error after failed transaction building.
-   */
   data class ViewingError(
     val sendAmount: BitcoinTransactionSendAmount,
     val error: Throwable,

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/SendUiStateMachineImpl.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/SendUiStateMachineImpl.kt
@@ -7,6 +7,7 @@ import build.wallet.bitcoin.transactions.BitcoinTransactionSendAmount
 import build.wallet.bitcoin.transactions.BitcoinTransactionSendAmount.ExactAmount
 import build.wallet.bitcoin.transactions.BitcoinTransactionSendAmount.SendAll
 import build.wallet.bitcoin.transactions.EstimatedTransactionPriority
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.di.ActivityScope
 import build.wallet.di.BitkeyInject
 import build.wallet.money.BitcoinMoney
@@ -156,13 +157,18 @@ class SendUiStateMachineImpl(
             },
             initialAmount = state.transferMoney,
             exchangeRates = exchangeRates,
+            coinControl = state.coinControl,
+            onCoinControlChanged = { coinControl ->
+              uiState = state.copy(coinControl = coinControl)
+            },
             onContinueClick = { sendAmount ->
               // Lock exchange rates for consistency in fee selection and confirmation screens
               lockedExchangeRates = exchangeRates
               rateLocked = true
               uiState = SelectingTransactionPriorityUiState(
                 recipientAddress = state.recipientAddress,
-                sendAmount = sendAmount
+                sendAmount = sendAmount,
+                coinControl = state.coinControl
               )
             },
             onContinueWithPreBuiltPsbts = { sendAmount, psbts ->
@@ -171,7 +177,8 @@ class SendUiStateMachineImpl(
               uiState = SelectingTransactionPriorityUiState(
                 recipientAddress = state.recipientAddress,
                 sendAmount = sendAmount,
-                preBuiltPsbts = psbts
+                preBuiltPsbts = psbts,
+                coinControl = state.coinControl
               )
             }
           )
@@ -195,11 +202,13 @@ class SendUiStateMachineImpl(
                   when (val amount = state.sendAmount) {
                     is ExactAmount -> amount.money
                     is SendAll -> defaultAmountEntryAmount
-                  }
+                  },
+                coinControl = state.coinControl
               )
             },
             fees = state.fees,
             preBuiltPsbts = state.preBuiltPsbts,
+            coinControl = state.coinControl,
             onTransferFailed = props.onExit,
             exchangeRates = exchangeRates,
             onTransferInitiated = { psbt, priority ->
@@ -241,6 +250,7 @@ class SendUiStateMachineImpl(
               sendAmount = state.sendAmount,
               exchangeRates = exchangeRates,
               preBuiltPsbts = state.preBuiltPsbts,
+              coinControl = state.coinControl,
               onBack = {
                 // Unlock rates so amount entry can observe live rates again.
                 // Keep lockedExchangeRates as fallback if fresh rates aren't available.
@@ -252,7 +262,8 @@ class SendUiStateMachineImpl(
                       when (val amount = state.sendAmount) {
                         is ExactAmount -> amount.money
                         is SendAll -> defaultAmountEntryAmount
-                      }
+                      },
+                    coinControl = state.coinControl
                   )
               },
               onContinue = { priority, fees ->
@@ -262,7 +273,8 @@ class SendUiStateMachineImpl(
                     recipientAddress = state.recipientAddress,
                     sendAmount = state.sendAmount,
                     fees = fees,
-                    preBuiltPsbts = state.preBuiltPsbts
+                    preBuiltPsbts = state.preBuiltPsbts,
+                    coinControl = state.coinControl
                   )
               }
             )
@@ -516,6 +528,7 @@ private sealed interface SendUiState {
     val recipientAddress: BitcoinAddress,
     val sendAmount: BitcoinTransactionSendAmount,
     val preBuiltPsbts: build.wallet.bitcoin.transactions.PsbtsForSendAmount? = null,
+    val coinControl: CoinControl? = null,
   ) : SendUiState
 
   /**
@@ -524,6 +537,7 @@ private sealed interface SendUiState {
   data class EnteringAmountUiState(
     val recipientAddress: BitcoinAddress,
     val transferMoney: Money,
+    val coinControl: CoinControl? = null,
   ) : SendUiState
 
   /**
@@ -535,6 +549,7 @@ private sealed interface SendUiState {
     val sendAmount: BitcoinTransactionSendAmount,
     val fees: ImmutableMap<EstimatedTransactionPriority, Fee>,
     val preBuiltPsbts: build.wallet.bitcoin.transactions.PsbtsForSendAmount? = null,
+    val coinControl: CoinControl? = null,
   ) : SendUiState
 
   /**

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/TransferAmountEntryUiStateMachine.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/TransferAmountEntryUiStateMachine.kt
@@ -39,6 +39,9 @@ data class TransferAmountEntryUiProps(
       val allowSendAll: Boolean = true,
       val minAmount: BitcoinMoney? = null,
       val maxAmount: BitcoinMoney? = null,
+      val coinControlLabel: String? = null,
+      val onChooseCoinsClick: ((BitcoinMoney) -> Unit)? = null,
+      val onClearCoinControl: (() -> Unit)? = null,
     ) : Flow
 
     data class Sell(

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/TransferAmountEntryUiStateMachineImpl.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/TransferAmountEntryUiStateMachineImpl.kt
@@ -20,10 +20,13 @@ import build.wallet.money.formatter.MoneyDisplayFormatter
 import build.wallet.statemachine.core.*
 import build.wallet.statemachine.money.calculator.MoneyCalculatorUiProps
 import build.wallet.statemachine.money.calculator.MoneyCalculatorUiStateMachine
+import build.wallet.statemachine.moneyhome.card.CardModel
 import build.wallet.statemachine.send.amountentry.TransferCardUiProps
 import build.wallet.statemachine.send.amountentry.TransferCardUiStateMachine
 import build.wallet.ui.components.label.LabelTreatment.Destructive
 import build.wallet.ui.components.label.LabelTreatment.Secondary
+import build.wallet.ui.model.StandardClick
+import build.wallet.ui.model.button.ButtonModel
 
 @BitkeyInject(ActivityScope::class)
 class TransferAmountEntryUiStateMachineImpl(
@@ -41,7 +44,8 @@ class TransferAmountEntryUiStateMachineImpl(
   @Suppress("CyclomaticComplexMethod")
   override fun model(props: TransferAmountEntryUiProps): ScreenModel {
     val flow = props.flow
-    val allowSendAll = (flow as? TransferAmountEntryUiProps.Flow.Send)?.allowSendAll ?: false
+    val sendFlow = flow as? TransferAmountEntryUiProps.Flow.Send
+    val allowSendAll = sendFlow?.allowSendAll ?: false
     val minimumAmount =
       when (flow) {
         is TransferAmountEntryUiProps.Flow.Send -> flow.minAmount
@@ -298,7 +302,7 @@ class TransferAmountEntryUiStateMachineImpl(
       }
     }
 
-    val cardModel =
+    val sendMaxCardModel =
       if (isSellFlow) {
         null
       } else {
@@ -315,6 +319,42 @@ class TransferAmountEntryUiStateMachineImpl(
           )
         )
       }
+
+    val cardModel = sendMaxCardModel ?: sendFlow?.let { send ->
+      when {
+        send.onChooseCoinsClick == null -> null
+        send.coinControlLabel != null -> CardModel(
+          title = LabelModel.StringWithStyledSubstringModel.from(
+            string = send.coinControlLabel,
+            substringToColor = emptyMap()
+          ),
+          subtitle = "Tap to edit selection",
+          leadingImage = null,
+          content = null,
+          style = CardModel.CardStyle.Outline(),
+          onClick = { send.onChooseCoinsClick.invoke(enteredBitcoinMoney) },
+          trailingButton = send.onClearCoinControl?.let { onClear ->
+            ButtonModel(
+              text = "Clear",
+              treatment = ButtonModel.Treatment.Tertiary,
+              size = ButtonModel.Size.Compact,
+              onClick = StandardClick(onClear)
+            )
+          }
+        )
+        else -> CardModel(
+          title = LabelModel.StringWithStyledSubstringModel.from(
+            string = "Choose coins",
+            substringToColor = emptyMap()
+          ),
+          subtitle = "Optional advanced selection",
+          leadingImage = null,
+          content = null,
+          style = CardModel.CardStyle.Outline(),
+          onClick = { send.onChooseCoinsClick.invoke(enteredBitcoinMoney) }
+        )
+      }
+    }
 
     val useSmartBar by remember(isSellFlow, allowSendAll, bitcoinBalance) {
       derivedStateOf { !isSellFlow && allowSendAll && !bitcoinBalance.total.isZero }

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/TransferAmountEntryUiStateMachineImpl.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/TransferAmountEntryUiStateMachineImpl.kt
@@ -320,7 +320,7 @@ class TransferAmountEntryUiStateMachineImpl(
         )
       }
 
-    val cardModel = sendMaxCardModel ?: sendFlow?.let { send ->
+    val chooseCoinsCardModel = sendFlow?.let { send ->
       when {
         send.onChooseCoinsClick == null -> null
         send.coinControlLabel != null -> CardModel(
@@ -354,6 +354,11 @@ class TransferAmountEntryUiStateMachineImpl(
           onClick = { send.onChooseCoinsClick.invoke(enteredBitcoinMoney) }
         )
       }
+    }
+    val cardModel = when {
+      chooseCoinsCardModel != null && sendFlow?.coinControlLabel != null -> chooseCoinsCardModel
+      sendMaxCardModel != null -> sendMaxCardModel
+      else -> chooseCoinsCardModel
     }
 
     val useSmartBar by remember(isSellFlow, allowSendAll, bitcoinBalance) {

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/TransferConfirmationUiStateMachine.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/TransferConfirmationUiStateMachine.kt
@@ -6,6 +6,7 @@ import build.wallet.bitcoin.transactions.BitcoinTransactionSendAmount
 import build.wallet.bitcoin.transactions.EstimatedTransactionPriority
 import build.wallet.bitcoin.transactions.Psbt
 import build.wallet.bitcoin.transactions.PsbtsForSendAmount
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.bitkey.account.FullAccount
 import build.wallet.money.exchange.ExchangeRate
 import build.wallet.statemachine.core.ScreenModel
@@ -23,6 +24,8 @@ interface TransferConfirmationUiStateMachine :
  * @property exchangeRates The exchange rates at the time the customer launches the send flow.
  * @property preBuiltPsbts Pre-built PSBTs for different transaction priorities. When provided,
  *   the state machine will use these PSBTs instead of creating new ones.
+ * @property coinControl optional user-selected confirmed UTXOs for classic PSBT rebuild;
+ *   null means automatic selection.
  * @property onBack callback when we want to go back to the last state of the send flow
  * @property onExit callback when we want to exit the send flow
  */
@@ -35,6 +38,7 @@ data class TransferConfirmationUiProps(
   val fees: ImmutableMap<EstimatedTransactionPriority, Fee>,
   val exchangeRates: ImmutableList<ExchangeRate>?,
   val preBuiltPsbts: PsbtsForSendAmount? = null,
+  val coinControl: CoinControl? = null,
   val onTransferInitiated: (psbt: Psbt, priority: EstimatedTransactionPriority) -> Unit,
   val onTransferFailed: () -> Unit,
   val onBack: () -> Unit,

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/TransferConfirmationUiStateMachineImpl.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/TransferConfirmationUiStateMachineImpl.kt
@@ -18,6 +18,7 @@ import build.wallet.bitcoin.transactions.BitcoinWalletService
 import build.wallet.bitcoin.transactions.EstimatedTransactionPriority
 import build.wallet.bitcoin.transactions.Psbt
 import build.wallet.bitcoin.transactions.TransactionPriorityPreference
+import build.wallet.bitcoin.utxo.toCoinSelectionStrategy
 import build.wallet.bitcoin.wallet.SpendingWallet
 import build.wallet.bitkey.factor.SigningFactor
 import build.wallet.bitkey.factor.SigningFactor.F8e
@@ -475,7 +476,8 @@ class TransferConfirmationUiStateMachineImpl(
           val constructionMethod = SpendingWallet.PsbtConstructionMethod.Regular(
             recipientAddress = props.recipientAddress,
             amount = props.sendAmount,
-            feePolicy = FeePolicy.Absolute(entry.value)
+            feePolicy = FeePolicy.Absolute(entry.value),
+            coinSelectionStrategy = props.coinControl.toCoinSelectionStrategy()
           )
           val psbtResult =
             createAppSignedPsbt(

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/fee/FeeSelectionUiStateMachine.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/fee/FeeSelectionUiStateMachine.kt
@@ -5,6 +5,7 @@ import build.wallet.bitcoin.fees.Fee
 import build.wallet.bitcoin.transactions.BitcoinTransactionSendAmount
 import build.wallet.bitcoin.transactions.EstimatedTransactionPriority
 import build.wallet.bitcoin.transactions.PsbtsForSendAmount
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.money.exchange.ExchangeRate
 import build.wallet.statemachine.core.BodyModel
 import build.wallet.statemachine.core.StateMachine
@@ -17,6 +18,7 @@ interface FeeSelectionUiStateMachine : StateMachine<FeeSelectionUiProps, BodyMod
  * @property fiatCurrency: The fiat currency to convert BTC amounts to and from.
  * @property preBuiltPsbts: Pre-built PSBTs for different transaction priorities. When provided,
  *   the state machine will use these PSBTs instead of creating new ones.
+ * @property coinControl: optional user-selected confirmed UTXOs; null means automatic selection.
  */
 data class FeeSelectionUiProps(
   val recipientAddress: BitcoinAddress,
@@ -24,6 +26,7 @@ data class FeeSelectionUiProps(
   val exchangeRates: ImmutableList<ExchangeRate>?,
   val preselectedPriority: EstimatedTransactionPriority? = null,
   val preBuiltPsbts: PsbtsForSendAmount? = null,
+  val coinControl: CoinControl? = null,
   val onBack: () -> Unit,
   val onContinue: (
     EstimatedTransactionPriority,

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/fee/FeeSelectionUiStateMachineImpl.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/fee/FeeSelectionUiStateMachineImpl.kt
@@ -262,7 +262,8 @@ class FeeSelectionUiStateMachineImpl(
           ?: EstimatedTransactionPriority.entries,
         account = account,
         recipientAddress = props.recipientAddress,
-        amount = props.sendAmount
+        amount = props.sendAmount,
+        coinControl = props.coinControl
       )
         .onFailure { onFeesLoadFailed(it) }
         .onSuccess {

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/utxo/UtxoSelectionBodyModel.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/utxo/UtxoSelectionBodyModel.kt
@@ -1,0 +1,88 @@
+package build.wallet.statemachine.send.utxo
+
+import build.wallet.analytics.events.screen.id.SendEventTrackerScreenId
+import build.wallet.compose.collections.buildImmutableList
+import build.wallet.statemachine.core.form.FormBodyModel
+import build.wallet.statemachine.core.form.FormHeaderModel
+import build.wallet.statemachine.core.form.FormMainContentModel.ListGroup
+import build.wallet.ui.model.StandardClick
+import build.wallet.ui.model.button.ButtonModel
+import build.wallet.ui.model.button.ButtonModel.Size.Footer
+import build.wallet.ui.model.list.ListGroupModel
+import build.wallet.ui.model.list.ListGroupModel.HeaderTreatment.PRIMARY
+import build.wallet.ui.model.list.ListGroupStyle.CARD_GROUP
+import build.wallet.ui.model.list.ListItemAccessory.CheckboxAccessory
+import build.wallet.ui.model.list.ListItemModel
+import build.wallet.ui.model.list.ListItemSideTextTint
+import build.wallet.ui.model.toolbar.ToolbarAccessoryModel.IconAccessory.Companion.BackAccessory
+import build.wallet.ui.model.toolbar.ToolbarMiddleAccessoryModel
+import build.wallet.ui.model.toolbar.ToolbarModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+data class UtxoSelectionBodyModel(
+  override val onBack: () -> Unit,
+  val utxoItems: ImmutableList<UtxoSelectionListItem>,
+  val headerSubline: String?,
+  val confirmEnabled: Boolean,
+  val onConfirm: () -> Unit,
+  val onClear: () -> Unit,
+  val showClear: Boolean,
+) : FormBodyModel(
+    id = SendEventTrackerScreenId.SEND_UTXO_SELECTION,
+    onBack = onBack,
+    toolbar = ToolbarModel(
+      leadingAccessory = BackAccessory(onClick = onBack),
+      middleAccessory = ToolbarMiddleAccessoryModel(title = "Choose coins")
+    ),
+    header = FormHeaderModel(
+      headline = "Choose coins",
+      subline = headerSubline
+    ),
+    mainContentList = buildImmutableList {
+      if (utxoItems.isNotEmpty()) {
+        ListGroup(
+          listGroupModel = ListGroupModel(
+            header = "Confirmed UTXOs",
+            items = utxoItems.map { item ->
+              ListItemModel(
+                title = item.valueLabel,
+                sideText = item.outpointLabel,
+                sideTextTint = ListItemSideTextTint.SECONDARY,
+                leadingAccessory = CheckboxAccessory(
+                  isChecked = item.isSelected,
+                  onClick = item.onToggle
+                ),
+                onClick = item.onToggle
+              )
+            }.toImmutableList(),
+            style = CARD_GROUP,
+            headerTreatment = PRIMARY
+          )
+        ).also(::add)
+      }
+    },
+    primaryButton = ButtonModel(
+      text = "Confirm",
+      isEnabled = confirmEnabled,
+      size = Footer,
+      onClick = StandardClick(onConfirm)
+    ),
+    secondaryButton = if (showClear) {
+      ButtonModel(
+        text = "Clear selection",
+        treatment = ButtonModel.Treatment.Secondary,
+        size = Footer,
+        onClick = StandardClick(onClear)
+      )
+    } else {
+      null
+    }
+  )
+
+data class UtxoSelectionListItem(
+  val valueLabel: String,
+  val outpointLabel: String,
+  val isSelected: Boolean,
+  val onToggle: () -> Unit,
+)

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/utxo/UtxoSelectionUiStateMachine.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/utxo/UtxoSelectionUiStateMachine.kt
@@ -1,0 +1,29 @@
+package build.wallet.statemachine.send.utxo
+
+import build.wallet.bitcoin.utxo.CoinControl
+import build.wallet.money.BitcoinMoney
+import build.wallet.statemachine.core.ScreenModel
+import build.wallet.statemachine.core.StateMachine
+
+/**
+ * Optional advanced affordance for picking confirmed UTXOs during send.
+ *
+ * Not a mandatory SendUi step. Hosted from amount entry as a nested screen.
+ */
+interface UtxoSelectionUiStateMachine : StateMachine<UtxoSelectionUiProps, ScreenModel>
+
+/**
+ * @property targetAmount send amount used for a soft underfunded check when ExactAmount;
+ *   null skips the soft check (e.g. SendAll).
+ * @property initialSelection previously chosen control to pre-check, or null for a fresh session.
+ * @property onConfirm validated [CoinControl] from confirmed inventory.
+ * @property onClear clear selection back to Automatic (parent sets null).
+ * @property onBack dismiss without changing parent selection.
+ */
+data class UtxoSelectionUiProps(
+  val targetAmount: BitcoinMoney? = null,
+  val initialSelection: CoinControl? = null,
+  val onConfirm: (CoinControl) -> Unit,
+  val onClear: () -> Unit,
+  val onBack: () -> Unit,
+)

--- a/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/utxo/UtxoSelectionUiStateMachineImpl.kt
+++ b/app/ui/features/public/src/commonMain/kotlin/build/wallet/statemachine/send/utxo/UtxoSelectionUiStateMachineImpl.kt
@@ -1,0 +1,99 @@
+package build.wallet.statemachine.send.utxo
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import build.wallet.bdk.bindings.BdkOutPoint
+import build.wallet.bitcoin.bdk.bitcoinAmount
+import build.wallet.bitcoin.bdk.transactionId
+import build.wallet.bitcoin.transactions.BitcoinWalletService
+import build.wallet.bitcoin.utxo.CoinControl
+import build.wallet.di.ActivityScope
+import build.wallet.di.BitkeyInject
+import build.wallet.money.BitcoinMoney
+import build.wallet.money.formatter.MoneyDisplayFormatter
+import build.wallet.statemachine.core.ScreenModel
+import com.github.michaelbull.result.get
+import kotlinx.collections.immutable.toImmutableList
+
+@BitkeyInject(ActivityScope::class)
+class UtxoSelectionUiStateMachineImpl(
+  private val bitcoinWalletService: BitcoinWalletService,
+  private val moneyDisplayFormatter: MoneyDisplayFormatter,
+) : UtxoSelectionUiStateMachine {
+  @Composable
+  override fun model(props: UtxoSelectionUiProps): ScreenModel {
+    val transactionsData by remember { bitcoinWalletService.transactionsData() }.collectAsState()
+    val confirmedUtxos = remember(transactionsData) {
+      transactionsData?.utxos?.confirmed.orEmpty()
+    }
+
+    var selectedOutpoints by remember {
+      mutableStateOf(props.initialSelection?.outpoints.orEmpty())
+    }
+
+    val selectedTotal = remember(confirmedUtxos, selectedOutpoints) {
+      confirmedUtxos
+        .filter { it.outPoint in selectedOutpoints }
+        .fold(BitcoinMoney.zero()) { acc, utxo -> acc + utxo.bitcoinAmount }
+    }
+
+    val targetAmount = props.targetAmount
+    val underfunded =
+      targetAmount != null && selectedOutpoints.isNotEmpty() && selectedTotal < targetAmount
+
+    val headerSubline = when {
+      confirmedUtxos.isEmpty() -> "No confirmed coins available."
+      selectedOutpoints.isEmpty() -> "Select one or more confirmed coins to spend."
+      underfunded && targetAmount != null -> {
+        val selectedLabel = moneyDisplayFormatter.format(selectedTotal)
+        val targetLabel = moneyDisplayFormatter.format(targetAmount)
+        "Selected total ($selectedLabel) is less than the send amount ($targetLabel)."
+      }
+      else -> {
+        val count = selectedOutpoints.size
+        val totalLabel = moneyDisplayFormatter.format(selectedTotal)
+        "$count selected · $totalLabel"
+      }
+    }
+
+    val utxoItems = confirmedUtxos
+      .sortedByDescending { it.txOut.value }
+      .map { utxo ->
+        val outpoint = utxo.outPoint
+        UtxoSelectionListItem(
+          valueLabel = moneyDisplayFormatter.format(utxo.bitcoinAmount),
+          outpointLabel = "${utxo.transactionId.truncated()}:${outpoint.vout}",
+          isSelected = outpoint in selectedOutpoints,
+          onToggle = {
+            selectedOutpoints = selectedOutpoints.toggle(outpoint)
+          }
+        )
+      }
+      .toImmutableList()
+
+    return UtxoSelectionBodyModel(
+      onBack = props.onBack,
+      utxoItems = utxoItems,
+      headerSubline = headerSubline,
+      confirmEnabled = selectedOutpoints.isNotEmpty(),
+      onConfirm = {
+        val coinControl = CoinControl.create(
+          inventory = confirmedUtxos,
+          selected = selectedOutpoints
+        ).get()
+        if (coinControl != null) {
+          props.onConfirm(coinControl)
+        }
+      },
+      onClear = props.onClear,
+      showClear = selectedOutpoints.isNotEmpty() || props.initialSelection != null
+    ).asModalFullScreen()
+  }
+}
+
+private fun Set<BdkOutPoint>.toggle(outpoint: BdkOutPoint): Set<BdkOutPoint> =
+  if (outpoint in this) this - outpoint else this + outpoint

--- a/app/ui/features/public/src/commonTest/kotlin/build/wallet/statemachine/send/SendAmountEntryUiStateMachineImplTests.kt
+++ b/app/ui/features/public/src/commonTest/kotlin/build/wallet/statemachine/send/SendAmountEntryUiStateMachineImplTests.kt
@@ -1,5 +1,6 @@
 package build.wallet.statemachine.send
 
+import build.wallet.bdk.bindings.BdkUtxoMock
 import build.wallet.bitcoin.address.someBitcoinAddress
 import build.wallet.bitcoin.transactions.BitcoinTransactionSendAmount
 import build.wallet.bitcoin.transactions.BitcoinTransactionSendAmount.ExactAmount
@@ -7,6 +8,7 @@ import build.wallet.bitcoin.transactions.BitcoinTransactionSendAmount.SendAll
 import build.wallet.bitcoin.transactions.BitcoinWalletServiceFake
 import build.wallet.bitcoin.transactions.PsbtMock
 import build.wallet.bitcoin.transactions.PsbtsForSendAmount
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.coroutines.turbine.turbines
 import build.wallet.feature.FeatureFlagDaoMock
 import build.wallet.feature.flags.PreBuiltPsbtFlowFeatureFlag
@@ -15,18 +17,24 @@ import build.wallet.money.BitcoinMoney
 import build.wallet.money.FiatMoney
 import build.wallet.money.currency.USD
 import build.wallet.money.exchange.ExchangeRateServiceFake
+import build.wallet.money.formatter.MoneyDisplayFormatterFake
 import build.wallet.statemachine.BodyStateMachineMock
 import build.wallet.statemachine.ScreenStateMachineMock
 import build.wallet.statemachine.core.LoadingSuccessBodyModel
 import build.wallet.statemachine.core.test
+import build.wallet.statemachine.send.utxo.UtxoSelectionUiProps
+import build.wallet.statemachine.send.utxo.UtxoSelectionUiStateMachine
 import build.wallet.statemachine.transactions.fee.FeeEstimationErrorUiProps
 import build.wallet.statemachine.transactions.fee.FeeEstimationErrorUiStateMachine
 import build.wallet.statemachine.ui.awaitBody
 import build.wallet.statemachine.ui.awaitBodyMock
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.get
 import com.ionspin.kotlin.bignum.integer.toBigInteger
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.collections.immutable.toImmutableList
@@ -42,15 +50,21 @@ class SendAmountEntryUiStateMachineImplTests : FunSpec({
     object : TransferAmountEntryUiStateMachine,
       ScreenStateMachineMock<TransferAmountEntryUiProps>("transfer-amount-entry") {}
 
+  val utxoSelectionUiStateMachine =
+    object : UtxoSelectionUiStateMachine,
+      ScreenStateMachineMock<UtxoSelectionUiProps>("utxo-selection") {}
+
   val feeEstimationErrorUiStateMachine =
     object : FeeEstimationErrorUiStateMachine,
       BodyStateMachineMock<FeeEstimationErrorUiProps>("fee-estimation-error") {}
 
   val stateMachine = SendAmountEntryUiStateMachineImpl(
     transferAmountEntryUiStateMachine = transferAmountEntryUiStateMachine,
+    utxoSelectionUiStateMachine = utxoSelectionUiStateMachine,
     preBuiltPsbtFlowFeatureFlag = preBuiltPsbtFlowFeatureFlag,
     bitcoinWalletService = bitcoinWalletService,
-    feeEstimationErrorUiStateMachine = feeEstimationErrorUiStateMachine
+    feeEstimationErrorUiStateMachine = feeEstimationErrorUiStateMachine,
+    moneyDisplayFormatter = MoneyDisplayFormatterFake
   )
 
   val recipientAddress = someBitcoinAddress
@@ -240,6 +254,73 @@ class SendAmountEntryUiStateMachineImplTests : FunSpec({
       awaitBodyMock<TransferAmountEntryUiProps> {
         initialAmount.shouldBe(FiatMoney.zero(USD))
       }
+    }
+  }
+
+  test("passes coinControl into createPsbtsForSendAmount") {
+    preBuiltPsbtFlowFeatureFlag.setFlagValue(true)
+
+    val sendAmount = ExactAmount(BitcoinMoney.sats(1.toBigInteger()))
+    val coinControl = CoinControl.create(
+      inventory = setOf(BdkUtxoMock),
+      selected = setOf(BdkUtxoMock.outPoint)
+    ).get().shouldNotBeNull()
+    val mockPsbts = PsbtsForSendAmount(
+      fastest = PsbtMock,
+      thirtyMinutes = PsbtMock,
+      sixtyMinutes = PsbtMock
+    )
+    bitcoinWalletService.createPsbtsForSendAmountResult = Ok(mockPsbts)
+
+    val props = SendAmountEntryUiProps(
+      recipientAddress = recipientAddress,
+      onBack = {},
+      initialAmount = FiatMoney.zero(USD),
+      exchangeRates = exchangeRates,
+      coinControl = coinControl,
+      onContinueClick = { error("Should not call onContinueClick") },
+      onContinueWithPreBuiltPsbts = { amount, psbts ->
+        onContinueWithPreBuiltPsbtsCalls.add(amount to psbts)
+      }
+    )
+
+    stateMachine.test(props) {
+      awaitBodyMock<TransferAmountEntryUiProps> {
+        onContinueClick(ContinueTransferParams(sendAmount = sendAmount))
+      }
+
+      awaitBody<LoadingSuccessBodyModel> {}
+
+      onContinueWithPreBuiltPsbtsCalls.awaitItem()
+      bitcoinWalletService.lastCreatePsbtsCoinControl.shouldBe(coinControl)
+    }
+  }
+
+  test("opens utxo picker and clears selection") {
+    val onCoinControlChangedCalls = turbines.create<CoinControl?>("onCoinControlChanged")
+
+    val props = SendAmountEntryUiProps(
+      recipientAddress = recipientAddress,
+      onBack = {},
+      initialAmount = FiatMoney.zero(USD),
+      exchangeRates = exchangeRates,
+      onCoinControlChanged = { onCoinControlChangedCalls.add(it) },
+      onContinueClick = {}
+    )
+
+    stateMachine.test(props) {
+      awaitBodyMock<TransferAmountEntryUiProps> {
+        val sendFlow = flow as TransferAmountEntryUiProps.Flow.Send
+        sendFlow.onChooseCoinsClick.shouldNotBeNull().invoke(BitcoinMoney.sats(1000))
+      }
+
+      awaitBodyMock<UtxoSelectionUiProps> {
+        onClear()
+      }
+
+      onCoinControlChangedCalls.awaitItem().shouldBeNull()
+
+      awaitBodyMock<TransferAmountEntryUiProps> {}
     }
   }
 })

--- a/app/ui/features/public/src/commonTest/kotlin/build/wallet/statemachine/send/SendUiStateMachineImplTests.kt
+++ b/app/ui/features/public/src/commonTest/kotlin/build/wallet/statemachine/send/SendUiStateMachineImplTests.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import build.wallet.bdk.bindings.BdkUtxoMock
 import build.wallet.bitcoin.address.someBitcoinAddress
 import build.wallet.bitcoin.balance.BitcoinBalanceFake
 import build.wallet.bitcoin.fees.Fee
@@ -14,6 +15,7 @@ import build.wallet.bitcoin.transactions.BitcoinWalletServiceFake
 import build.wallet.bitcoin.transactions.EstimatedTransactionPriority.*
 import build.wallet.bitcoin.transactions.PsbtMock
 import build.wallet.bitcoin.transactions.TransactionsDataMock
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.bitkey.keybox.FullAccountMock
 import build.wallet.coroutines.turbine.turbines
 import build.wallet.money.BitcoinMoney
@@ -41,6 +43,7 @@ import build.wallet.statemachine.ui.awaitBody
 import build.wallet.statemachine.ui.awaitBodyMock
 import build.wallet.time.ClockFake
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.get
 import com.ionspin.kotlin.bignum.integer.toBigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
@@ -168,6 +171,38 @@ class SendUiStateMachineImplTests : FunSpec({
             feeAmount.shouldBe(feeMap.getValue(FASTEST).amount)
             this.transferAmount.shouldBe(transferAmount)
           }
+        }
+      }
+    }
+
+    test("threads coinControl through fee and confirmation") {
+      val selectedCoins = CoinControl.create(
+        inventory = setOf(BdkUtxoMock),
+        selected = setOf(BdkUtxoMock.outPoint)
+      ).get().shouldNotBeNull()
+
+      stateMachine.test(props) {
+        awaitBodyMock<BitcoinAddressRecipientUiProps> {
+          onRecipientEntered(someBitcoinAddress)
+        }
+
+        awaitBodyMock<SendAmountEntryUiProps> {
+          this.coinControl.shouldBeNull()
+          onCoinControlChanged(selectedCoins)
+        }
+
+        awaitBodyMock<SendAmountEntryUiProps> {
+          this.coinControl.shouldBe(selectedCoins)
+          onContinueClick(ExactAmount(BitcoinMoney.sats(amountToSend.toBigInteger())))
+        }
+
+        awaitBodyMock<FeeSelectionUiProps> {
+          this.coinControl.shouldBe(selectedCoins)
+          onContinue(FASTEST, feeMap)
+        }
+
+        awaitBodyMock<TransferConfirmationUiProps> {
+          this.coinControl.shouldBe(selectedCoins)
         }
       }
     }

--- a/app/ui/features/public/src/commonTest/kotlin/build/wallet/statemachine/send/TransferConfirmationUiStateMachineImplRegularTests.kt
+++ b/app/ui/features/public/src/commonTest/kotlin/build/wallet/statemachine/send/TransferConfirmationUiStateMachineImplRegularTests.kt
@@ -13,6 +13,10 @@ import build.wallet.bitcoin.transactions.EstimatedTransactionPriority.*
 import build.wallet.bitcoin.transactions.Psbt
 import build.wallet.bitcoin.transactions.PsbtMock
 import build.wallet.bitcoin.transactions.TransactionPriorityPreferenceFake
+import build.wallet.bdk.bindings.BdkUtxoMock
+import build.wallet.bitcoin.utxo.CoinControl
+import build.wallet.bitcoin.wallet.CoinSelectionStrategy
+import build.wallet.bitcoin.wallet.SpendingWallet
 import build.wallet.bitcoin.wallet.SpendingWalletMock
 import build.wallet.bitkey.keybox.FullAccountMock
 import build.wallet.bitkey.keybox.FullAccountConfigMock
@@ -44,6 +48,7 @@ import build.wallet.statemachine.ui.awaitUntilBody
 import build.wallet.statemachine.ui.clickPrimaryButton
 import build.wallet.ui.model.icon.IconImage
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.get
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
@@ -408,5 +413,26 @@ class TransferConfirmationUiStateMachineImplRegularTests : FunSpec({
     }
 
     onTransferInitiatedCalls.awaitItem()
+  }
+
+  test("classic rebuild passes Strict coinSelectionStrategy from coinControl") {
+    val coinControl = CoinControl.create(
+      inventory = setOf(BdkUtxoMock),
+      selected = setOf(BdkUtxoMock.outPoint)
+    ).get().shouldNotBeNull()
+    spendingWallet.createSignedPsbtResult = Ok(appSignedPsbt)
+
+    stateMachine.test(props.copy(coinControl = coinControl)) {
+      awaitBody<LoadingSuccessBodyModel> {
+        state.shouldBe(LoadingSuccessBodyModel.State.Loading)
+      }
+
+      mobilePayService.getDailySpendingLimitStatusCalls.awaitItem()
+
+      val construction = spendingWallet.lastCreateSignedPsbtConstructionType
+        .shouldBeInstanceOf<SpendingWallet.PsbtConstructionMethod.Regular>()
+      construction.coinSelectionStrategy.shouldBeInstanceOf<CoinSelectionStrategy.Strict>()
+      cancelAndIgnoreRemainingEvents()
+    }
   }
 })

--- a/app/ui/features/public/src/commonTest/kotlin/build/wallet/statemachine/send/fee/FeeSelectionUiStateMachineImplTests.kt
+++ b/app/ui/features/public/src/commonTest/kotlin/build/wallet/statemachine/send/fee/FeeSelectionUiStateMachineImplTests.kt
@@ -15,7 +15,9 @@ import build.wallet.bitcoin.transactions.EstimatedTransactionPriority.*
 import build.wallet.bitcoin.transactions.PsbtMock
 import build.wallet.bitcoin.transactions.PsbtsForSendAmount
 import build.wallet.bitcoin.transactions.TransactionPriorityPreferenceFake
+import build.wallet.bdk.bindings.BdkUtxoMock
 import build.wallet.bitcoin.transactions.TransactionsDataMock
+import build.wallet.bitcoin.utxo.CoinControl
 import build.wallet.bitkey.keybox.FullAccountMock
 import build.wallet.compose.collections.immutableListOf
 import build.wallet.coroutines.turbine.turbines
@@ -31,8 +33,10 @@ import build.wallet.statemachine.ui.awaitBody
 import build.wallet.statemachine.ui.clickPrimaryButton
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.get
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
@@ -88,6 +92,7 @@ class FeeSelectionUiStateMachineImplTests : FunSpec({
           SIXTY_MINUTES to Fee(BitcoinMoney.btc(1.0))
         )
       )
+    bitcoinTransactionFeeEstimator.lastCoinControl = null
     transactionPriorityPreference.preference = null
     bitcoinTransactionBaseCalculator.minimumSatsRequired = BitcoinMoney.zero()
   }
@@ -405,6 +410,27 @@ class FeeSelectionUiStateMachineImplTests : FunSpec({
       }
 
       onContinueCalls.awaitItem().shouldBe(THIRTY_MINUTES)
+    }
+  }
+
+  test("passes coinControl into fee estimator") {
+    val coinControl = CoinControl.create(
+      inventory = setOf(BdkUtxoMock),
+      selected = setOf(BdkUtxoMock.outPoint)
+    ).get().shouldNotBeNull()
+
+    stateMachine.test(props.copy(coinControl = coinControl)) {
+      awaitBody<LoadingSuccessBodyModel> {}
+      awaitBody<FormBodyModel> {}
+      bitcoinTransactionFeeEstimator.lastCoinControl.shouldBe(coinControl)
+    }
+  }
+
+  test("null coinControl means automatic selection at fee estimator") {
+    stateMachine.test(props) {
+      awaitBody<LoadingSuccessBodyModel> {}
+      awaitBody<FormBodyModel> {}
+      bitcoinTransactionFeeEstimator.lastCoinControl.shouldBeNull()
     }
   }
 })

--- a/app/ui/features/public/src/commonTest/kotlin/build/wallet/statemachine/send/utxo/UtxoSelectionUiStateMachineImplTests.kt
+++ b/app/ui/features/public/src/commonTest/kotlin/build/wallet/statemachine/send/utxo/UtxoSelectionUiStateMachineImplTests.kt
@@ -1,0 +1,122 @@
+package build.wallet.statemachine.send.utxo
+
+import build.wallet.bdk.bindings.BdkOutPoint
+import build.wallet.bdk.bindings.BdkUtxoMock
+import build.wallet.bdk.bindings.BdkUtxoMock2
+import build.wallet.bitcoin.transactions.BitcoinWalletServiceFake
+import build.wallet.bitcoin.transactions.TransactionsDataMock
+import build.wallet.bitcoin.utxo.CoinControl
+import build.wallet.bitcoin.utxo.Utxos
+import build.wallet.coroutines.turbine.turbines
+import build.wallet.money.BitcoinMoney
+import build.wallet.money.formatter.MoneyDisplayFormatterFake
+import build.wallet.statemachine.core.form.FormBodyModel
+import build.wallet.statemachine.core.form.FormMainContentModel.ListGroup
+import build.wallet.statemachine.core.test
+import build.wallet.statemachine.ui.awaitBody
+import build.wallet.ui.model.list.ListItemAccessory.CheckboxAccessory
+import com.github.michaelbull.result.get
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class UtxoSelectionUiStateMachineImplTests : FunSpec({
+  val bitcoinWalletService = BitcoinWalletServiceFake()
+  val stateMachine = UtxoSelectionUiStateMachineImpl(
+    bitcoinWalletService = bitcoinWalletService,
+    moneyDisplayFormatter = MoneyDisplayFormatterFake
+  )
+
+  val utxoA = BdkUtxoMock
+  val utxoB = BdkUtxoMock2.copy(outPoint = BdkOutPoint(txid = "def", vout = 1u))
+  val inventory = setOf(utxoA, utxoB)
+
+  val onConfirmCalls = turbines.create<CoinControl>("onConfirm")
+  val onClearCalls = turbines.create<Unit>("onClear")
+  val onBackCalls = turbines.create<Unit>("onBack")
+
+  beforeTest {
+    bitcoinWalletService.reset()
+    bitcoinWalletService.transactionsData.value = TransactionsDataMock.copy(
+      utxos = Utxos(confirmed = inventory, unconfirmed = emptySet())
+    )
+  }
+
+  fun props(
+    targetAmount: BitcoinMoney? = BitcoinMoney.sats(1),
+    initialSelection: CoinControl? = null,
+  ) = UtxoSelectionUiProps(
+    targetAmount = targetAmount,
+    initialSelection = initialSelection,
+    onConfirm = { onConfirmCalls.add(it) },
+    onClear = { onClearCalls.add(Unit) },
+    onBack = { onBackCalls.add(Unit) }
+  )
+
+  test("lists confirmed utxos and confirms selection") {
+    stateMachine.test(props()) {
+      awaitBody<FormBodyModel> {
+        val listGroup = mainContentList.first().shouldBeInstanceOf<ListGroup>()
+        listGroup.listGroupModel.items.shouldHaveSize(2)
+        primaryButton.shouldNotBeNull().isEnabled.shouldBeFalse()
+
+        val firstCheckbox = listGroup.listGroupModel.items.first()
+          .leadingAccessory.shouldBeInstanceOf<CheckboxAccessory>()
+        firstCheckbox.onClick()
+      }
+
+      awaitBody<FormBodyModel> {
+        primaryButton.shouldNotBeNull().isEnabled.shouldBeTrue()
+        primaryButton!!.onClick()
+      }
+
+      val confirmed = onConfirmCalls.awaitItem()
+      confirmed.count shouldBe 1
+    }
+  }
+
+  test("shows soft underfunded messaging for ExactAmount") {
+    stateMachine.test(props(targetAmount = BitcoinMoney.sats(100))) {
+      awaitBody<FormBodyModel> {
+        val listGroup = mainContentList.first().shouldBeInstanceOf<ListGroup>()
+        listGroup.listGroupModel.items.first()
+          .leadingAccessory.shouldBeInstanceOf<CheckboxAccessory>()
+          .onClick()
+      }
+
+      awaitBody<FormBodyModel> {
+        header.shouldNotBeNull().sublineModel.shouldNotBeNull().string
+          .shouldContain("less than the send amount")
+        primaryButton.shouldNotBeNull().isEnabled.shouldBeTrue()
+      }
+    }
+  }
+
+  test("clear invokes onClear") {
+    val initial = CoinControl.create(
+      inventory = inventory,
+      selected = setOf(utxoA.outPoint)
+    ).get().shouldNotBeNull()
+
+    stateMachine.test(props(initialSelection = initial)) {
+      awaitBody<FormBodyModel> {
+        secondaryButton.shouldNotBeNull().onClick()
+      }
+      onClearCalls.awaitItem()
+    }
+  }
+
+  test("back invokes onBack") {
+    stateMachine.test(props()) {
+      awaitBody<FormBodyModel> {
+        onBack.shouldNotBeNull().invoke()
+      }
+      onBackCalls.awaitItem()
+    }
+  }
+})


### PR DESCRIPTION
## Summary

Optional coin control on send. Customers can pick confirmed UTXO(s) from the amount screen. Maintainers get a single `CoinControl?` boundary that maps to `CoinSelectionStrategy.Strict` on both classic and prebuilt PSBT paths. `null` keeps today's automatic BDK selection.

- Add `CoinControl`, a validated domain value for user-chosen confirmed UTXOs
- Thread `CoinControl?` through amount → fee → confirmation
- Add an optional **Choose coins** picker (confirmed only, multi-select, clear back to automatic)

## How it works

### Flow

```
Recipient → Amount ⇄ Choose coins (optional) → Fee tiers → Confirm → Sign + broadcast
```

- **Automatic (`coinControl == null`).** Unchanged send path. Fee ladder may use `Preselected` only to stabilize inputs across fee tiers, not as user coin control.
- **Coin control set.** Amount hosts a nested picker. After Confirm or Clear, flow returns to amount. Prebuilt PSBTs are built on Continue with the chosen `CoinControl`. Classic fee estimate and confirm rebuild use the same strategy.

### What `CoinControl` encodes

- Validated non-empty subset of `TransactionsData.utxos.confirmed`
- Derived `spendableTotal` and `toStrictStrategy()` (dummy `BdkTxIn`s; only outpoint matters)
- Empty / unknown outpoints fail at `CoinControl.create`
- UI never builds strategy enums; it threads `CoinControl?` only

### Where it is applied

| Path | Call site |
|---|---|
| Prebuilt | `createPsbtsForSendAmount(..., coinControl)` |
| Classic fee | `getFeesForTransaction(..., coinControl)` |
| Classic confirm | `Regular(..., coinControl.toCoinSelectionStrategy())` |

When set, all three fee tiers share the same `Strict` set. The Default→Preselected ladder is skipped.

### Construction mapping

| Intent | API | Notes |
|---|---|---|
| Exact / SendAll from chosen coins | `Regular` + `Strict` | Change allowed; underfunded fails closed |
| Automatic selection | `Regular` + `Default` | `Preselected` only for fee-tier input locking |
| Consolidate / drain set | `DrainAllFromUtxos` | Wrong tool for partial exact sends (out of scope) |

### Layer map

| Layer | Owns |
|---|---|
| `UtxoSelectionUiStateMachine` | Confirmed list, multi-select, soft underfunded copy, `CoinControl.create` |
| Send amount entry | Optional Choose coins card; hosts picker; passes `coinControl` into prebuilt build |
| `SendUi` states | Threads `CoinControl?` amount → fee → confirm |
| `BitcoinWalletService` / fee estimator | Strict×3 when set; Default ladder when null |
| `SpendingWallet` + BDK TxBuilder | `addUtxos` + `manuallySelectedOnly` for Strict |

### Gotchas

- **Strict is fail-closed.** If selected value cannot cover amount + fee, PSBT creation errors. The picker shows a soft warning; it does not silently top up via `Preselected`.
- **`Preselected` ≠ coin control.** Existing fee-ladder `Preselected` only reuses prior PSBT inputs so tiers stay comparable. BDK may still add more UTXOs.
- **Confirmed inventory only.** Same policy as consolidation. Unconfirmed UTXOs are not listed.
- **Send Max card vs selection.** When coins are selected, the amount screen keeps the selection card (edit/clear) even if Send Max would otherwise replace it.

### Design notes

Arena compared three shapes; chose domain `CoinControl?` over raw `Set<BdkOutPoint>?` and over a mandatory post-amount picker step with strategy-typed service APIs.

## Commits

1. Domain `CoinControl` + wallet/fee plumbing
2. Send UI picker + state threading
3. Keep coin selection visible when Send Max would replace it

## Test plan

- [ ] Unit: `CoinControlTests`, `UtxoSelectionUiStateMachineImplTests`, send amount / fee / confirmation threading tests
- [ ] Manual: send with automatic selection (unchanged)
- [ ] Manual: Choose coins → select one UTXO → exact amount with change → confirm inputs match selection
- [ ] Manual: underfunded Strict selection fails with insufficient-funds UX (no silent extra inputs)
- [ ] Manual: Clear selection restores automatic coin selection
- [ ] Manual: with coins selected, amount at max still shows selection card (edit/clear)
- [ ] Manual: prebuilt and classic paths both honor the same Strict inputs across fee tiers